### PR TITLE
Fix #5: Centralize --dangerously-skip-permissions

### DIFF
--- a/src/adapter/claude.rs
+++ b/src/adapter/claude.rs
@@ -298,14 +298,14 @@ impl AgentRuntime for ClaudeAdapter {
         proxy::send_keys(&tmux_target, &format!("cd '{}'", worktree_path.display())).await?;
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-        // Launch claude
-        proxy::send_keys(&tmux_target, "claude code --dangerously-skip-permissions .").await?;
+        // Launch the agent with autonomous permissions
+        proxy::send_keys(&tmux_target, swarm.agent_type.launch_cmd()).await?;
 
-        // Wait for Claude to initialize
+        // Wait for agent to initialize
         tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
-        // Send /fix-loop
-        self.start_worker_loop(&tmux_target).await?;
+        // Send the worker loop command
+        proxy::send_keys(&tmux_target, swarm.agent_type.worker_loop_cmd()).await?;
 
         Ok(AgentInfo {
             id: format!("worker-{next_idx}"),
@@ -318,7 +318,7 @@ impl AgentRuntime for ClaudeAdapter {
     }
 
     async fn start_worker_loop(&self, tmux_target: &str) -> Result<()> {
-        proxy::send_keys(tmux_target, "/autocoder:fix-loop").await
+        proxy::send_keys(tmux_target, AgentType::Claude.worker_loop_cmd()).await
     }
 
     async fn stop(&self, swarm: &Swarm) -> Result<()> {

--- a/src/model/swarm.rs
+++ b/src/model/swarm.rs
@@ -49,6 +49,24 @@ impl AgentType {
             AgentType::Droid => ".factory/loops",
         }
     }
+
+    /// The shell command to launch this agent with autonomous permissions.
+    pub fn launch_cmd(&self) -> &str {
+        match self {
+            AgentType::Claude => "claude code --dangerously-skip-permissions .",
+            AgentType::Codex => "codex --dangerously-skip-permissions",
+            AgentType::Droid => "droid",
+            AgentType::Gemini => "gemini --sandbox=false",
+        }
+    }
+
+    /// The slash command to start the worker fix-loop.
+    pub fn worker_loop_cmd(&self) -> &str {
+        match self {
+            AgentType::Claude => "/autocoder:fix-loop",
+            _ => "/fix-loop",
+        }
+    }
 }
 
 /// The workflow type for a swarm.


### PR DESCRIPTION
## Summary
- Add `launch_cmd()` to `AgentType` returning the full launch command with `--dangerously-skip-permissions` for each agent type
- Add `worker_loop_cmd()` to `AgentType` returning the appropriate fix-loop slash command
- Update `ClaudeAdapter` to use these centralized methods instead of hardcoded strings

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)