### PR TITLE
Implement #13: Number keys 1-9 jump to workers

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -491,6 +491,20 @@ impl App {
                         }
                     }
                 }
+                KeyCode::Char(c @ '1'..='9') => {
+                    // Jump directly to worker by number (1=worker-0, 2=worker-1, etc.)
+                    let worker_idx = (c as usize) - ('1' as usize);
+                    if let Some(swarm) = self.swarms.get(swarm_idx) {
+                        if let Some(worker) = swarm.workers.get(worker_idx) {
+                            self.agent_view = AgentView::new();
+                            self.agent_view.scroll_to_bottom();
+                            self.screen = Screen::AgentView {
+                                swarm_idx,
+                                agent_id: worker.id.clone(),
+                            };
+                        }
+                    }
+                }
                 _ => {}
             }
         }

--- a/src/ui/repo_view.rs
+++ b/src/ui/repo_view.rs
@@ -167,10 +167,12 @@ impl RepoView {
             ]))
         } else {
             Paragraph::new(Line::from(vec![
-                Span::styled(" Enter", theme::title_style()),
-                Span::styled(" drill into agent  ", theme::help_style()),
+                Span::styled("1-9", theme::title_style()),
+                Span::styled(" jump to worker  ", theme::help_style()),
+                Span::styled("Enter", theme::title_style()),
+                Span::styled(" drill in  ", theme::help_style()),
                 Span::styled("m", theme::title_style()),
-                Span::styled(" manager session  ", theme::help_style()),
+                Span::styled(" manager  ", theme::help_style()),
                 Span::styled("d", theme::title_style()),
                 Span::styled(" shutdown  ", theme::help_style()),
                 Span::styled("f", theme::title_style()),


### PR DESCRIPTION
## Summary
- Add number key shortcuts (1-9) in Repo View to jump directly to a worker's Agent View
- Key 1 = worker-0, 2 = worker-1, etc. Non-existent workers silently ignored
- Updated help bar with `1-9 jump to worker` hint

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)