### PR TITLE
Fix #20: Resize tmux panes to terminal width before capture

### DIFF
--- a/src/tmux/proxy.rs
+++ b/src/tmux/proxy.rs
@@ -3,8 +3,22 @@ use tokio::process::Command;
 use tokio::sync::mpsc;
 use std::time::Duration;
 
-/// Capture the current content of a tmux pane.
+/// Resize a tmux pane to the given width.
+pub async fn resize_pane(target: &str, width: u16) -> Result<()> {
+    let _ = Command::new("tmux")
+        .args(["resize-pane", "-t", target, "-x", &width.to_string()])
+        .output()
+        .await;
+    Ok(())
+}
+
+/// Capture the current content of a tmux pane, optionally resizing it first.
 pub async fn capture_pane(target: &str, scrollback_lines: u32) -> Result<String> {
+    // Resize pane to match the TUI's terminal width so content wraps correctly
+    if let Ok((cols, _)) = crossterm::terminal::size() {
+        resize_pane(target, cols).await?;
+    }
+
     let output = Command::new("tmux")
         .args([
             "capture-pane",


### PR DESCRIPTION
## Summary
- Add `resize_pane` helper to resize tmux panes to a given width
- Before each `capture_pane`, resize the pane to match the TUI's terminal width via `crossterm::terminal::size()`
- Fixes content wrapping at narrow pane width instead of full screen width

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)