### PR TITLE
Fix #24: Alt+0 focuses manager session

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -198,8 +198,10 @@ impl App {
 
                 if swarm_idx < self.swarms.len() {
                     if c == '0' {
-                        // Alt+0: go to Repo View
+                        // Alt+0: go to Repo View with manager focused
                         self.repo_view = RepoView::new();
+                        self.repo_view.focus_manager = true;
+                        self.repo_view.manager_scroll = u16::MAX;
                         self.screen = Screen::RepoView { swarm_idx };
                         return Ok(());
                     } else {


### PR DESCRIPTION
## Summary
- Alt+0 now navigates to Swarm View AND focuses the manager input with scroll at bottom
- Consistent with Alt+1-9 which jump directly to worker sessions

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)