### PR TITLE
Add D key to tear down entire swarm

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -533,6 +533,23 @@ impl App {
                         }
                     }
                 }
+                KeyCode::Char('D') => {
+                    // Tear down the entire swarm (kill all sessions)
+                    if let Some(swarm) = self.swarms.get(swarm_idx) {
+                        let project = swarm.project_name.clone();
+                        tracing::info!("Tearing down swarm for {project}");
+                        if let Err(e) = self.adapter.teardown(swarm).await {
+                            tracing::error!("Teardown failed: {e}");
+                            self.status_message =
+                                Some(format!("Teardown failed: {e}"));
+                        } else {
+                            self.swarms.remove(swarm_idx);
+                            self.status_message =
+                                Some(format!("Swarm {project} shut down"));
+                            self.screen = Screen::ReposList;
+                        }
+                    }
+                }
                 KeyCode::Char(c @ '1'..='9') => {
                     // Jump directly to worker by number (1=worker-0, 2=worker-1, etc.)
                     let worker_idx = (c as usize) - ('1' as usize);

--- a/src/ui/repo_view.rs
+++ b/src/ui/repo_view.rs
@@ -190,6 +190,8 @@ impl RepoView {
                 Span::styled(" fix-loop  ", theme::help_style()),
                 Span::styled("a", theme::title_style()),
                 Span::styled(" add worker  ", theme::help_style()),
+                Span::styled("D", theme::title_style()),
+                Span::styled(" stop swarm  ", theme::help_style()),
                 Span::styled("Esc", theme::title_style()),
                 Span::styled(" back  ", theme::help_style()),
                 Span::styled("q", theme::title_style()),


### PR DESCRIPTION
## Summary
- `D` (shift+d) in Repo View kills all worker sessions and manager session
- Removes swarm from list, returns to repos list
- Help bar updated with `D stop swarm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)