### PR TITLE
Change swarm teardown to Alt+z global shortcut

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -183,8 +183,30 @@ impl App {
             return Ok(());
         }
 
-        // Global: Alt+0 jumps to Repo View (swarm view), Alt+1-9 jumps to worker
+        // Global Alt shortcuts: Alt+0 swarm view, Alt+1-9 workers, Alt+z stop swarm
         if key.modifiers.contains(KeyModifiers::ALT) {
+            // Alt+z: tear down the current swarm
+            if key.code == KeyCode::Char('z') {
+                let swarm_idx = match &self.screen {
+                    Screen::RepoView { swarm_idx } => *swarm_idx,
+                    Screen::AgentView { swarm_idx, .. } => *swarm_idx,
+                    _ => self.repos_list.selected().unwrap_or(0),
+                };
+                if let Some(swarm) = self.swarms.get(swarm_idx) {
+                    let project = swarm.project_name.clone();
+                    tracing::info!("Tearing down swarm for {project}");
+                    if let Err(e) = self.adapter.teardown(swarm).await {
+                        tracing::error!("Teardown failed: {e}");
+                        self.status_message = Some(format!("Teardown failed: {e}"));
+                    } else {
+                        self.swarms.remove(swarm_idx);
+                        self.status_message = Some(format!("Swarm {project} shut down"));
+                        self.screen = Screen::ReposList;
+                    }
+                }
+                return Ok(());
+            }
+
             if let KeyCode::Char(c @ '0'..='9') = key.code {
                 // Find the current swarm index (use 0 if on repos list)
                 let swarm_idx = match &self.screen {
@@ -530,23 +552,6 @@ impl App {
                                 self.status_message =
                                     Some(format!("Shutting down {id}..."));
                             }
-                        }
-                    }
-                }
-                KeyCode::Char('D') => {
-                    // Tear down the entire swarm (kill all sessions)
-                    if let Some(swarm) = self.swarms.get(swarm_idx) {
-                        let project = swarm.project_name.clone();
-                        tracing::info!("Tearing down swarm for {project}");
-                        if let Err(e) = self.adapter.teardown(swarm).await {
-                            tracing::error!("Teardown failed: {e}");
-                            self.status_message =
-                                Some(format!("Teardown failed: {e}"));
-                        } else {
-                            self.swarms.remove(swarm_idx);
-                            self.status_message =
-                                Some(format!("Swarm {project} shut down"));
-                            self.screen = Screen::ReposList;
                         }
                     }
                 }

--- a/src/ui/repo_view.rs
+++ b/src/ui/repo_view.rs
@@ -190,7 +190,7 @@ impl RepoView {
                 Span::styled(" fix-loop  ", theme::help_style()),
                 Span::styled("a", theme::title_style()),
                 Span::styled(" add worker  ", theme::help_style()),
-                Span::styled("D", theme::title_style()),
+                Span::styled("Alt+z", theme::title_style()),
                 Span::styled(" stop swarm  ", theme::help_style()),
                 Span::styled("Esc", theme::title_style()),
                 Span::styled(" back  ", theme::help_style()),


### PR DESCRIPTION
## Summary
- Replace `D` (shift+d) with `Alt+z` for swarm teardown
- Works globally from any screen (Repo View, Agent View, Repos List)
- Consistent with Alt+0-9 navigation pattern
- Harder to hit accidentally than shift+d

🤖 Generated with [Claude Code](https://claude.com/claude-code)