### PR TITLE
Fix #108: Surface blocked issues as attention items

### DIFF
--- a/src/ui/repos_list.rs
+++ b/src/ui/repos_list.rs
@@ -92,7 +92,7 @@ impl ReposListView {
                 Cell::from("Workflow"),
                 Cell::from("Runtime"),
                 Cell::from("Sessions"),
-                Cell::from("Waiting"),
+                Cell::from("Attention"),
                 Cell::from("Issues"),
             ])
             .style(theme::header_style());
@@ -104,7 +104,7 @@ impl ReposListView {
             for s in swarms {
                 let busy = s.busy_count();
                 let total = s.workers.len();
-                let waiting = count_attention(s);
+                let waiting = s.attention_count() + count_attention(s);
 
                 // Build issue priority summary from cache
                 let issue_summary = if let Some(cache) = issue_caches.get(&s.project_name) {
@@ -149,7 +149,7 @@ impl ReposListView {
                     Cell::from(s.agent_type.to_string()),
                     Cell::from(format!("{busy}/{total} working")),
                     Cell::from(if waiting > 0 {
-                        format!("{waiting} input")
+                        format!("⚠ {waiting}")
                     } else {
                         "—".to_string()
                     })

--- a/src/ui/swarm_view.rs
+++ b/src/ui/swarm_view.rs
@@ -81,7 +81,7 @@ impl SwarmView {
         .split(chunks[1]);
 
         // --- Header line ---
-        let attention = count_attention(swarm);
+        let attention = swarm.attention_count() + count_attention(swarm);
         let working = swarm.busy_count();
         let total_workers = swarm.workers.len();
         let idle = total_workers - working;
@@ -102,7 +102,7 @@ impl SwarmView {
         ];
         if attention > 0 {
             let style = theme::attention_blink_style(blink);
-            header_spans.push(Span::styled(format!("⚠ {attention} waiting"), style));
+            header_spans.push(Span::styled(format!("⚠ {attention} need attention"), style));
         }
         let header = Paragraph::new(Line::from(header_spans));
         f.render_widget(header, chunks[0]);


### PR DESCRIPTION
## Summary

- Use `Swarm::attention_count()` (blocked GitHub issues from `issue_cache`) combined with `count_attention()` (agents waiting for input) for the repos list "Attention" column
- Rename "Waiting" column to "Attention" in Repos List table header
- Update Swarm View header to show `⚠ N need attention` instead of `⚠ N waiting`
- The Repos List now shows `⚠ N` when there are items needing human review

## Test plan
- [ ] All 104 tests pass (`cargo test`)
- [ ] Repos list "Attention" column shows count when blocked issues exist
- [ ] Swarm view header shows `⚠ N need attention` when blocked issues are present

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)