### PR TITLE
Fix #119: Show inline blocked-issue detail in Swarm View

### DIFF
--- a/src/model/issue.rs
+++ b/src/model/issue.rs
@@ -91,7 +91,7 @@ pub struct GitHubIssue {
     pub assigned_worker: Option<String>,
 }
 
-const BLOCKING_LABELS: &[&str] = &[
+pub const BLOCKING_LABELS: &[&str] = &[
     "needs-design",
     "needs-clarification",
     "needs-approval",

--- a/src/ui/swarm_view.rs
+++ b/src/ui/swarm_view.rs
@@ -63,10 +63,22 @@ impl SwarmView {
             .filter(|i| i.matches_filter(self.issue_filter))
             .collect();
 
+        // Pre-compute attention data before layout (needed for dynamic sizing)
+        let attention = count_attention(swarm, issues);
+        let working = swarm.busy_count();
+        let total_workers = swarm.workers.len();
+        let idle = total_workers - working;
+        let avail_issues = issues.iter().filter(|i| !i.is_blocked() && !i.is_being_worked() && i.state == crate::model::issue::IssueState::Open).count();
+        let blocked_issues: Vec<&GitHubIssue> = issues.iter().filter(|i| i.is_blocked()).collect();
+        let blocked_count = blocked_issues.len();
+
+        // Header is 1 line normally; 2 lines when there are blocked issues to surface inline
+        let header_height: u16 = if blocked_count > 0 { 2 } else { 1 };
+
         let chunks = Layout::vertical([
-            Constraint::Length(1),             // Header line
-            Constraint::Min(4),               // Body (manager + workers/issues)
-            Constraint::Length(2),            // Help bar
+            Constraint::Length(header_height),  // Header line(s)
+            Constraint::Min(4),                 // Body (manager + workers/issues)
+            Constraint::Length(2),              // Help bar
         ])
         .split(area);
 
@@ -80,14 +92,6 @@ impl SwarmView {
         ])
         .split(chunks[1]);
 
-        // --- Header line ---
-        let attention = count_attention(swarm, issues);
-        let working = swarm.busy_count();
-        let total_workers = swarm.workers.len();
-        let idle = total_workers - working;
-        let avail_issues = issues.iter().filter(|i| !i.is_blocked() && !i.is_being_worked() && i.state == crate::model::issue::IssueState::Open).count();
-        let blocked_issues = issues.iter().filter(|i| i.is_blocked()).count();
-
         let mut header_spans = vec![
             Span::styled(format!(" {} ", swarm.project_name), theme::title_style()),
             Span::styled("Active ", Style::default().fg(ratatui::style::Color::Green)),
@@ -96,7 +100,7 @@ impl SwarmView {
                 theme::help_style(),
             ),
             Span::styled(
-                format!("Issues: {} avail, {} blocked  ", avail_issues, blocked_issues),
+                format!("Issues: {} avail, {} blocked  ", avail_issues, blocked_count),
                 theme::help_style(),
             ),
         ];
@@ -106,7 +110,38 @@ impl SwarmView {
         }
         let left_len: usize = header_spans.iter().map(|s| s.content.len()).sum();
         header_spans.push(theme::hostname_right_span(left_len, chunks[0].width as usize));
-        let header = Paragraph::new(Line::from(header_spans));
+
+        // Build header lines: status line + optional inline attention row
+        let mut header_lines = vec![Line::from(header_spans)];
+        if blocked_count > 0 {
+            let mut attn_spans = vec![
+                Span::styled(" ⚠ ", theme::attention_style()),
+            ];
+            let show_n = blocked_count.min(3);
+            for (idx, issue) in blocked_issues.iter().take(show_n).enumerate() {
+                if idx > 0 {
+                    attn_spans.push(Span::styled("  ", theme::help_style()));
+                }
+                let blocking_label = issue.labels
+                    .iter()
+                    .find(|l| crate::model::issue::BLOCKING_LABELS.contains(&l.as_str()))
+                    .map(|s| s.as_str())
+                    .unwrap_or("blocked");
+                attn_spans.push(Span::styled(
+                    format!("#{} [{}] {}", issue.number, blocking_label, truncate(&issue.title, 30)),
+                    theme::attention_style(),
+                ));
+            }
+            if blocked_count > 3 {
+                attn_spans.push(Span::styled(
+                    format!("  … and {} more (Tab→Issues)", blocked_count - 3),
+                    theme::help_style(),
+                ));
+            }
+            header_lines.push(Line::from(attn_spans));
+        }
+
+        let header = Paragraph::new(header_lines);
         f.render_widget(header, chunks[0]);
 
         // --- Manager panel ---


### PR DESCRIPTION
Implements the attention row in Swarm View that surfaces blocked issues inline without requiring Tab to the Issues panel.

## Changes
- When `blocked_count > 0`, header expands from 1 to 2 lines
- Attention row shows up to 3 blocked issues: `⚠ #N [label] Title`
- If more than 3: `… and N more (Tab→Issues)`  
- Exported `BLOCKING_LABELS` as `pub` for use in `swarm_view`

Closes #119