### PR TITLE
Fix #127: Remove dead key handlers in Issues panel and AgentView

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2040,49 +2040,9 @@ impl App {
                             }
                         }
                     }
-                    KeyCode::Char('d') => {
+                    KeyCode::Char('d') | KeyCode::Char(' ') => {
                         // Dispatch selected issue to an idle worker
-                        if let Some(swarm) = self.swarms.get(swarm_idx) {
-                            let issues: Vec<&GitHubIssue> = self.issue_caches
-                                .get(&swarm.project_name)
-                                .map(|c| c.issues.iter().filter(|i| i.matches_filter(self.swarm_view.issue_filter)).collect())
-                                .unwrap_or_default();
-                            if let Some(issue) = self.swarm_view.selected_issue()
-                                .and_then(|idx| issues.get(idx))
-                            {
-                                let issue_num = issue.number;
-                                let agent_type = swarm.agent_type.clone();
-                                let idle_worker = swarm.workers.iter()
-                                    .find(|w| {
-                                        !w.is_manager
-                                            && w.dispatched_issue.is_none()
-                                            && matches!(w.status.state, crate::model::status::AgentState::Idle)
-                                    })
-                                    .map(|w| w.tmux_target.clone());
-                                if let Some(target) = idle_worker {
-                                    if let Some(cmd) = self.worker_dispatch_cmd(&agent_type, issue_num) {
-                                        tracing::info!("Manual dispatch #{issue_num} to {target}");
-                                        if let Ok(()) = crate::tmux::proxy::send_keys_no_enter(&self.transport, &target, &cmd).await {
-                                            tokio::time::sleep(Duration::from_millis(200)).await;
-                                            crate::tmux::proxy::send_keys_no_enter(&self.transport, &target, "Enter").await.ok();
-                                            // Track dispatch in worker
-                                            if let Some(swarm_mut) = self.swarms.get_mut(swarm_idx) {
-                                                if let Some(worker) = swarm_mut.workers.iter_mut()
-                                                    .find(|w| w.tmux_target == target)
-                                                {
-                                                    worker.dispatched_issue = Some(issue_num);
-                                                }
-                                            }
-                                            self.status_message = Some(format!("Dispatched #{issue_num} to {target}"));
-                                        }
-                                    } else {
-                                        self.status_message = Some(format!("No dispatch command configured for {agent_type}"));
-                                    }
-                                } else {
-                                    self.status_message = Some("No idle workers available".to_string());
-                                }
-                            }
-                        }
+                        self.dispatch_selected_issue(swarm_idx).await;
                     }
                     KeyCode::Char('g') => {
                         // Open selected issue in browser via gh issue view --web
@@ -2114,10 +2074,6 @@ impl App {
                                 self.status_message = Some(format!("Opening issue #{} in browser", issue.number));
                             }
                         }
-                    }
-                    KeyCode::Char('d') | KeyCode::Char(' ') => {
-                        // Dispatch selected issue to an idle worker
-                        self.dispatch_selected_issue(swarm_idx).await;
                     }
                     _ => {}
                 }
@@ -2509,14 +2465,6 @@ impl App {
             KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL)
                 && !key.modifiers.contains(KeyModifiers::ALT) => {
                 self.agent_view.input.insert_char(c);
-                return Ok(());
-            }
-            KeyCode::Home => {
-                self.agent_view.scroll_offset = 0;
-                return Ok(());
-            }
-            KeyCode::End => {
-                self.agent_view.scroll_to_bottom();
                 return Ok(());
             }
             _ => {}


### PR DESCRIPTION
## Summary
- Issues panel: removes inline 44-line duplicate `d` dispatch handler that shadowed the `d | Space` arm; Space key for dispatch was previously unreachable
- Issues panel: consolidates to single `KeyCode::Char('d') | KeyCode::Char(' ')` arm calling `dispatch_selected_issue()`
- AgentView: removes dead `Home`/`End` handlers that were never reached (identical handlers appear earlier in the same match block)
- All three `unreachable_patterns` compiler warnings eliminated

## Test plan
- [ ] `cargo build` completes with no `unreachable_patterns` warnings
- [ ] All 107 tests pass
- [ ] Space key dispatches selected issue (previously broken)
- [ ] `d` key still dispatches selected issue via `dispatch_selected_issue()` helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)