### PR TITLE
Fix #4: Navigate to manager panel when pressing Up at top of workers list

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1859,7 +1859,9 @@ impl App {
                         self.swarm_view.next_worker(worker_count);
                     }
                     KeyCode::Up | KeyCode::Char('k') => {
-                        self.swarm_view.prev_worker(worker_count);
+                        if self.swarm_view.prev_worker(worker_count) {
+                            self.swarm_focus = SwarmPanel::Manager;
+                        }
                     }
                     KeyCode::Enter => {
                         // Drill into selected worker's agent view

--- a/src/ui/swarm_view.rs
+++ b/src/ui/swarm_view.rs
@@ -434,10 +434,15 @@ impl SwarmView {
         self.workers_table.select(Some((i + 1) % len));
     }
 
-    pub fn prev_worker(&mut self, len: usize) {
-        if len == 0 { return; }
+    /// Returns `true` if already at the top (caller should focus the manager panel).
+    pub fn prev_worker(&mut self, len: usize) -> bool {
+        if len == 0 { return true; }
         let i = self.workers_table.selected().unwrap_or(0);
-        self.workers_table.select(Some(if i == 0 { len - 1 } else { i - 1 }));
+        if i == 0 {
+            return true;
+        }
+        self.workers_table.select(Some(i - 1));
+        false
     }
 
     pub fn selected_worker(&self) -> Option<usize> {


### PR DESCRIPTION
## Summary

- `prev_worker()` now returns `bool` — `true` when already at the first row
- In `handle_repo_view_key`, pressing Up/k at the top of the Workers panel now switches `swarm_focus` to `SwarmPanel::Manager`
- Manager session output was already embedded above the workers table in the existing `swarm_view` layout

## Test plan
- [ ] Open repo view; navigate to Workers panel
- [ ] Press Up/k repeatedly until focus moves to the Manager panel
- [ ] Verify Tab still cycles Manager → Workers → Issues as before
- [ ] Verify Down navigates normally within Workers without premature focus change

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)