### PR TITLE
Fix #148: Don't revive/heal intentionally stopped swarms

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -246,6 +246,8 @@ pub struct App {
     pub show_help: bool,
     /// Rich feedback dialog state (None = closed).
     pub feedback_state: Option<crate::ui::feedback_dialog::FeedbackState>,
+    /// Projects intentionally stopped by the user — excluded from auto-heal and revival.
+    intentionally_stopped: std::collections::HashSet<String>,
 }
 
 impl App {
@@ -324,6 +326,7 @@ impl App {
             keybindings: crate::config::keybindings::KeyBindings::load(),
             show_help: false,
             feedback_state: None,
+            intentionally_stopped: std::collections::HashSet::new(),
         };
 
         // Scan for available repos (git directories in cwd or children)
@@ -1386,6 +1389,7 @@ impl App {
                     if idx < self.swarms.len() {
                         let swarm = self.swarms[idx].clone();
                         let project = swarm.project_name.clone();
+                        self.intentionally_stopped.insert(project.clone());
                         self.status_message = Some(format!("Tearing down {project}..."));
                         if let Err(e) = self.adapter.teardown(&swarm).await {
                             self.status_message = Some(format!("Teardown error: {e}"));
@@ -1689,6 +1693,7 @@ impl App {
                     if idx < self.swarms.len() {
                         let swarm = self.swarms[idx].clone();
                         let project = swarm.project_name.clone();
+                        self.intentionally_stopped.insert(project.clone());
                         self.status_message = Some(format!("Tearing down {project}..."));
                         if let Err(e) = self.adapter.teardown(&swarm).await {
                             self.status_message = Some(format!("Teardown error: {e}"));
@@ -3020,6 +3025,9 @@ impl App {
         let mut all_repairs = Vec::new();
 
         for i in 0..self.swarms.len() {
+            if self.intentionally_stopped.contains(&self.swarms[i].project_name) {
+                continue;
+            }
             match self.adapter.heal_workers(&mut self.swarms[i]).await {
                 Ok(repairs) => {
                     if !repairs.is_empty() {
@@ -3043,7 +3051,10 @@ impl App {
 
     /// Re-launch any agents that have dropped back to a shell prompt (e.g. after a self-update).
     async fn revive_dropped_agents(&mut self) {
-        let swarms: Vec<_> = self.swarms.iter().filter(|s| !s.manager.tmux_target.is_empty()).cloned().collect();
+        let intentionally_stopped = self.intentionally_stopped.clone();
+        let swarms: Vec<_> = self.swarms.iter()
+            .filter(|s| !s.manager.tmux_target.is_empty() && !intentionally_stopped.contains(&s.project_name))
+            .cloned().collect();
         for swarm in swarms {
             if let Err(e) = self.adapter.revive_agents(&swarm).await {
                 tracing::warn!("revive_agents failed for {}: {e}", swarm.project_name);


### PR DESCRIPTION
## Summary
- Adds `intentionally_stopped: HashSet<String>` field to `App` struct
- Populated with the project name immediately before `adapter.teardown()` is called (both in repos list and repo view handlers)
- `heal_all_workers()` and `revive_dropped_agents()` now skip any project in this set, preventing torn-down sessions from being automatically recreated within 30–60 seconds

## Root Cause
`heal_workers()` in `claude.rs` recreates the entire tmux session when it finds the session gone. If teardown partially fails (session killed but worktree removal errors → `Err` returned → swarm stays in `self.swarms`), the periodic heal timers would revive the session the user just stopped.

## Test plan
- [ ] Launch a swarm, confirm it starts
- [ ] Press `d` to teardown, confirm with `y`
- [ ] Wait 60+ seconds — verify the session does NOT reappear
- [ ] Launch a new swarm and verify auto-healing still works for non-stopped swarms

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)