### PR TITLE
Fix #154: Add unit tests for detect_waiting_for_input and RepoView navigation

### DIFF
--- a/src/model/swarm.rs
+++ b/src/model/swarm.rs
@@ -425,4 +425,58 @@ mod tests {
         assert_eq!(AgentType::Claude.status_dir(), ".codex/loops");
         assert_eq!(AgentType::Droid.status_dir(), ".factory/loops");
     }
+
+    // --- detect_waiting_for_input ---
+
+    #[test]
+    fn waiting_detected_for_bypass_permissions_prompt() {
+        assert!(detect_waiting_for_input("bypass permissions\nsome output"));
+    }
+
+    #[test]
+    fn waiting_detected_for_allow_prompt() {
+        assert!(detect_waiting_for_input("Running tool...\nAllow?"));
+    }
+
+    #[test]
+    fn waiting_detected_for_allow_this_action() {
+        assert!(detect_waiting_for_input("allow this action (y/n)"));
+    }
+
+    #[test]
+    fn waiting_detected_for_yn_brackets() {
+        assert!(detect_waiting_for_input("Continue? [Y/n]"));
+        assert!(detect_waiting_for_input("Continue? [y/N]"));
+    }
+
+    #[test]
+    fn waiting_detected_for_interrupted_state() {
+        assert!(detect_waiting_for_input(
+            "Some output\nWhat should Claude do instead?\nmore"
+        ));
+    }
+
+    #[test]
+    fn waiting_detected_for_interrupted_with_prompt_indicator() {
+        assert!(detect_waiting_for_input("Interrupted\nSome context\n❯"));
+    }
+
+    #[test]
+    fn waiting_detected_for_shift_tab_bypass_line() {
+        assert!(detect_waiting_for_input(
+            "bypass permissions on /some/file (shift+tab to allow)"
+        ));
+    }
+
+    #[test]
+    fn waiting_not_detected_for_normal_output() {
+        assert!(!detect_waiting_for_input(
+            "Running cargo build...\nCompiling foo v1.0\nFinished"
+        ));
+    }
+
+    #[test]
+    fn waiting_not_detected_for_empty_string() {
+        assert!(!detect_waiting_for_input(""));
+    }
 }

--- a/src/ui/repo_view.rs
+++ b/src/ui/repo_view.rs
@@ -686,3 +686,132 @@ fn truncate_str(s: &str, max_len: usize) -> String {
         format!("{}…", &s[..max_len - 1])
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn view() -> RepoView {
+        RepoView::new()
+    }
+
+    // --- next_worker / previous_worker ---
+
+    #[test]
+    fn next_worker_advances_selection() {
+        let mut rv = view();
+        rv.worker_list_state.select(Some(0));
+        rv.next_worker(3);
+        assert_eq!(rv.selected_worker(), Some(1));
+    }
+
+    #[test]
+    fn next_worker_wraps_at_end() {
+        let mut rv = view();
+        rv.worker_list_state.select(Some(2));
+        rv.next_worker(3);
+        assert_eq!(rv.selected_worker(), Some(0));
+    }
+
+    #[test]
+    fn next_worker_is_noop_for_empty_list() {
+        let mut rv = view();
+        rv.worker_list_state.select(Some(0));
+        rv.next_worker(0);
+        assert_eq!(rv.selected_worker(), Some(0));
+    }
+
+    #[test]
+    fn previous_worker_moves_up() {
+        let mut rv = view();
+        rv.worker_list_state.select(Some(2));
+        let at_top = rv.previous_worker(3);
+        assert!(!at_top);
+        assert_eq!(rv.selected_worker(), Some(1));
+    }
+
+    #[test]
+    fn previous_worker_returns_true_at_top() {
+        let mut rv = view();
+        rv.worker_list_state.select(Some(0));
+        let at_top = rv.previous_worker(3);
+        assert!(at_top);
+        assert_eq!(rv.selected_worker(), Some(0));
+    }
+
+    #[test]
+    fn previous_worker_returns_true_for_empty_list() {
+        let mut rv = view();
+        let at_top = rv.previous_worker(0);
+        assert!(at_top);
+    }
+
+    // --- next_issue / previous_issue ---
+
+    #[test]
+    fn next_issue_advances_beyond_header() {
+        let mut rv = view();
+        rv.issue_list_state.select(Some(0)); // header row
+        rv.next_issue(3);
+        assert_eq!(rv.issue_list_state.selected(), Some(1));
+    }
+
+    #[test]
+    fn next_issue_stops_at_last_item() {
+        let mut rv = view();
+        rv.issue_list_state.select(Some(3));
+        rv.next_issue(3); // max index = 3
+        assert_eq!(rv.issue_list_state.selected(), Some(3));
+    }
+
+    #[test]
+    fn next_issue_is_noop_for_empty_list() {
+        let mut rv = view();
+        rv.issue_list_state.select(Some(0));
+        rv.next_issue(0);
+        assert_eq!(rv.issue_list_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn previous_issue_moves_up() {
+        let mut rv = view();
+        rv.issue_list_state.select(Some(2));
+        let at_top = rv.previous_issue();
+        assert!(!at_top);
+        assert_eq!(rv.issue_list_state.selected(), Some(1));
+    }
+
+    #[test]
+    fn previous_issue_returns_true_at_header_row() {
+        let mut rv = view();
+        rv.issue_list_state.select(Some(1)); // first real issue
+        let at_top = rv.previous_issue();
+        assert!(at_top);
+    }
+
+    #[test]
+    fn previous_issue_returns_true_at_zero() {
+        let mut rv = view();
+        rv.issue_list_state.select(Some(0));
+        let at_top = rv.previous_issue();
+        assert!(at_top);
+    }
+
+    // --- selected_issue_idx ---
+
+    #[test]
+    fn selected_issue_idx_accounts_for_header_offset() {
+        let mut rv = view();
+        rv.issue_list_state.select(Some(1));
+        assert_eq!(rv.selected_issue_idx(), Some(0));
+        rv.issue_list_state.select(Some(3));
+        assert_eq!(rv.selected_issue_idx(), Some(2));
+    }
+
+    #[test]
+    fn selected_issue_idx_returns_none_for_header_row() {
+        let mut rv = view();
+        rv.issue_list_state.select(Some(0));
+        assert_eq!(rv.selected_issue_idx(), None);
+    }
+}


### PR DESCRIPTION
## Summary
- 9 tests for `detect_waiting_for_input` covering all waiting-state heuristics and normal/empty false-positive cases
- 14 tests for `RepoView` navigation: `next/previous_worker`, `next/previous_issue` (wrap + sentinel), and `selected_issue_idx` header offset
- No production code changed; test count 107 → 130

## Test plan
- [ ] `cargo test` passes (130 tests)

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)