### PR TITLE
Fix #156: Display stale agent status warnings using timestamp field

### DIFF
--- a/src/model/status.rs
+++ b/src/model/status.rs
@@ -30,9 +30,19 @@ impl std::fmt::Display for AgentState {
 /// Parsed status of an agent from its status file.
 #[derive(Debug, Clone)]
 pub struct AgentStatus {
-    #[allow(dead_code)] // Parsed for future use in status age display
     pub timestamp: Option<NaiveDateTime>,
     pub state: AgentState,
+}
+
+impl AgentStatus {
+    /// Returns `true` when the status file timestamp is older than `threshold_secs` seconds.
+    /// Returns `false` if there is no timestamp (can't determine staleness).
+    pub fn is_stale(&self, threshold_secs: u64) -> bool {
+        let Some(ts) = self.timestamp else { return false };
+        let now = chrono::Local::now().naive_local();
+        let age = now.signed_duration_since(ts);
+        age.num_seconds() > threshold_secs as i64
+    }
 }
 
 impl Default for AgentStatus {
@@ -438,5 +448,33 @@ mod tests {
             "Done: done"
         );
         assert_eq!(AgentState::Stopped.to_string(), "Stopped");
+    }
+
+    // --- is_stale ---
+
+    #[test]
+    fn is_stale_returns_false_when_timestamp_is_recent() {
+        let now = chrono::Local::now().naive_local();
+        let status = AgentStatus {
+            timestamp: Some(now - chrono::Duration::seconds(60)),
+            state: AgentState::Idle,
+        };
+        assert!(!status.is_stale(300));
+    }
+
+    #[test]
+    fn is_stale_returns_true_when_timestamp_is_old() {
+        let old = chrono::Local::now().naive_local() - chrono::Duration::seconds(600);
+        let status = AgentStatus {
+            timestamp: Some(old),
+            state: AgentState::Idle,
+        };
+        assert!(status.is_stale(300));
+    }
+
+    #[test]
+    fn is_stale_returns_false_when_no_timestamp() {
+        let status = AgentStatus { timestamp: None, state: AgentState::Idle };
+        assert!(!status.is_stale(300));
     }
 }

--- a/src/ui/agent_view.rs
+++ b/src/ui/agent_view.rs
@@ -78,6 +78,12 @@ impl AgentView {
         if agent.waiting_for_input {
             title_spans.push(Span::styled(" NEEDS INPUT", theme::waiting_style()));
         }
+        if agent.status.is_stale(300) {
+            title_spans.push(Span::styled(
+                " (stale)",
+                ratatui::style::Style::default().fg(ratatui::style::Color::Yellow),
+            ));
+        }
         title_spans.push(Span::styled(path_label, theme::help_style()));
         let left_len = id_len + role_len + path_len
             + if agent.waiting_for_input { " NEEDS INPUT".len() } else { 0 }

--- a/src/ui/repo_view.rs
+++ b/src/ui/repo_view.rs
@@ -281,6 +281,8 @@ impl RepoView {
                 let key_label = format!("{} ", idx + 1);
                 let (dot, dot_style) = if w.waiting_for_input {
                     ("⚠ ", theme::waiting_style())
+                } else if w.status.is_stale(300) {
+                    ("⚠ ", ratatui::style::Style::default().fg(ratatui::style::Color::Yellow))
                 } else {
                     match &w.status.state {
                         crate::model::status::AgentState::Working { .. } => {


### PR DESCRIPTION
## Summary
- Removes `#[allow(dead_code)]` from `AgentStatus.timestamp` (already parsed, now used)
- Adds `is_stale(threshold_secs: u64) -> bool` helper on `AgentStatus`
- Agent view shows `(stale)` in yellow when status file is >5 min old
- Repo view worker list shows `⚠` (yellow) dot prefix for stale workers
- 3 unit tests for `is_stale`; all 110 tests pass

## Test plan
- [ ] `cargo test` passes (110 tests)
- [ ] Manual: agent with old status file shows `⚠` in worker list and `(stale)` in agent view

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)