### PR TITLE
Fix #153: Add per-worker completed issue count to Repo View

### DIFF
--- a/src/adapter/claude.rs
+++ b/src/adapter/claude.rs
@@ -498,6 +498,7 @@ impl ClaudeAdapter {
             current_issue: None,
             current_issue_title: None,
             waiting_for_input: false,
+            completed_issue_count: 0,
         };
 
         let mut workers = Vec::new();
@@ -545,6 +546,7 @@ impl ClaudeAdapter {
                     current_issue: None,
                     current_issue_title: None,
                     waiting_for_input: false,
+            completed_issue_count: 0,
                 });
                 worker_num += 1;
             }
@@ -967,6 +969,7 @@ impl AgentRuntime for ClaudeAdapter {
             current_issue: None,
             current_issue_title: None,
             waiting_for_input: false,
+            completed_issue_count: 0,
         })
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1289,6 +1289,7 @@ impl App {
                 current_issue: None,
                 current_issue_title: None,
                 waiting_for_input: false,
+                completed_issue_count: 0,
             },
             workers: Vec::new(),
             issue_cache: crate::model::issue::IssueCache::default(),
@@ -3259,7 +3260,9 @@ impl App {
                                 crate::model::status::AgentState::Idle |
                                 crate::model::status::AgentState::Stopped
                             ) {
-                                agent.dispatched_issue = None;
+                                if agent.dispatched_issue.take().is_some() {
+                                    agent.completed_issue_count += 1;
+                                }
                             }
                             agent.status = new_status;
                         }

--- a/src/model/swarm.rs
+++ b/src/model/swarm.rs
@@ -151,6 +151,8 @@ pub struct AgentInfo {
     pub current_issue_title: Option<String>,
     /// Whether the agent is waiting for user input (detected from pane content)
     pub waiting_for_input: bool,
+    /// Number of issues completed (dispatched → cleared) in this session.
+    pub completed_issue_count: u32,
 }
 
 /// Detect if pane content indicates the session is waiting for user input.
@@ -336,6 +338,7 @@ mod tests {
             current_issue: None,
             current_issue_title: None,
             waiting_for_input: false,
+            completed_issue_count: 0,
         };
         let mut cache = IssueCache::default();
         cache.issues = issues;

--- a/src/ui/repo_view.rs
+++ b/src/ui/repo_view.rs
@@ -340,10 +340,16 @@ impl RepoView {
                     ratatui::style::Style::default()
                 };
 
+                let done_label = if w.completed_issue_count > 0 {
+                    format!(" ({} done)", w.completed_issue_count)
+                } else {
+                    String::new()
+                };
                 let line1 = Line::from(vec![
                     Span::styled(key_label, theme::help_style()),
                     Span::styled(dot, if w.waiting_for_input { row_style } else { dot_style }),
                     Span::styled(role_label, if w.waiting_for_input { row_style } else { theme::title_style() }),
+                    Span::styled(done_label, theme::help_style()),
                 ]);
                 let line2 = Line::from(vec![
                     Span::styled("  ", row_style),

--- a/src/ui/repos_list.rs
+++ b/src/ui/repos_list.rs
@@ -288,6 +288,7 @@ mod tests {
             current_issue: None,
             current_issue_title: None,
             waiting_for_input: false,
+            completed_issue_count: 0,
         }
     }
 

--- a/src/ui/swarm_view.rs
+++ b/src/ui/swarm_view.rs
@@ -552,6 +552,7 @@ mod tests {
             current_issue: None,
             current_issue_title: None,
             waiting_for_input: false,
+            completed_issue_count: 0,
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `completed_issue_count: u32` to `AgentInfo` (default 0)
- Increments counter when worker transitions `dispatched_issue: Some(n) → None` on Idle/Stopped
- Repo View worker list shows `(N done)` next to role name when count > 0

## Test plan
- [ ] `cargo test` passes (107 tests)
- [ ] Manual: dispatch an issue to a worker, wait for it to complete, verify `(1 done)` appears

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)