### PR TITLE
Fix #152: Show worker resurrection/heal status in Repo View

### DIFF
--- a/src/adapter/claude.rs
+++ b/src/adapter/claude.rs
@@ -498,6 +498,7 @@ impl ClaudeAdapter {
             current_issue: None,
             current_issue_title: None,
             waiting_for_input: false,
+            resurrection_attempts: 0,
         };
 
         let mut workers = Vec::new();
@@ -545,6 +546,7 @@ impl ClaudeAdapter {
                     current_issue: None,
                     current_issue_title: None,
                     waiting_for_input: false,
+            resurrection_attempts: 0,
                 });
                 worker_num += 1;
             }
@@ -967,6 +969,7 @@ impl AgentRuntime for ClaudeAdapter {
             current_issue: None,
             current_issue_title: None,
             waiting_for_input: false,
+            resurrection_attempts: 0,
         })
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1289,6 +1289,7 @@ impl App {
                 current_issue: None,
                 current_issue_title: None,
                 waiting_for_input: false,
+            resurrection_attempts: 0,
             },
             workers: Vec::new(),
             issue_cache: crate::model::issue::IssueCache::default(),
@@ -3043,7 +3044,28 @@ impl App {
 
     /// Re-launch any agents that have dropped back to a shell prompt (e.g. after a self-update).
     async fn revive_dropped_agents(&mut self) {
-        let swarms: Vec<_> = self.swarms.iter().filter(|s| !s.manager.tmux_target.is_empty()).cloned().collect();
+        // Identify workers that look dropped before attempting revival.
+        let mut dropped: Vec<(usize, usize)> = Vec::new(); // (swarm_idx, worker_idx)
+        for (si, swarm) in self.swarms.iter().enumerate() {
+            if swarm.manager.tmux_target.is_empty() {
+                continue;
+            }
+            for (wi, worker) in swarm.workers.iter().enumerate() {
+                if matches!(
+                    worker.status.state,
+                    crate::model::status::AgentState::Stopped | crate::model::status::AgentState::Unknown(_)
+                ) {
+                    dropped.push((si, wi));
+                }
+            }
+        }
+        // Increment resurrection_attempts for dropped workers before reviving.
+        for (si, wi) in &dropped {
+            self.swarms[*si].workers[*wi].resurrection_attempts += 1;
+        }
+        let swarms: Vec<_> = self.swarms.iter()
+            .filter(|s| !s.manager.tmux_target.is_empty())
+            .cloned().collect();
         for swarm in swarms {
             if let Err(e) = self.adapter.revive_agents(&swarm).await {
                 tracing::warn!("revive_agents failed for {}: {e}", swarm.project_name);
@@ -3260,6 +3282,13 @@ impl App {
                                 crate::model::status::AgentState::Stopped
                             ) {
                                 agent.dispatched_issue = None;
+                            }
+                            // Reset resurrection counter when agent returns to healthy state
+                            if matches!(new_status.state,
+                                crate::model::status::AgentState::Working { .. } |
+                                crate::model::status::AgentState::Idle
+                            ) {
+                                agent.resurrection_attempts = 0;
                             }
                             agent.status = new_status;
                         }

--- a/src/model/swarm.rs
+++ b/src/model/swarm.rs
@@ -151,6 +151,8 @@ pub struct AgentInfo {
     pub current_issue_title: Option<String>,
     /// Whether the agent is waiting for user input (detected from pane content)
     pub waiting_for_input: bool,
+    /// Number of times the TUI has attempted to revive this agent in the current session.
+    pub resurrection_attempts: u32,
 }
 
 /// Detect if pane content indicates the session is waiting for user input.
@@ -336,6 +338,7 @@ mod tests {
             current_issue: None,
             current_issue_title: None,
             waiting_for_input: false,
+            resurrection_attempts: 0,
         };
         let mut cache = IssueCache::default();
         cache.issues = issues;

--- a/src/ui/repo_view.rs
+++ b/src/ui/repo_view.rs
@@ -279,8 +279,16 @@ impl RepoView {
             .enumerate()
             .map(|(idx, w)| {
                 let key_label = format!("{} ", idx + 1);
+                let reviving_style = ratatui::style::Style::default().fg(ratatui::style::Color::Cyan);
+                let attention_style = ratatui::style::Style::default()
+                    .fg(ratatui::style::Color::Red)
+                    .add_modifier(ratatui::style::Modifier::BOLD);
                 let (dot, dot_style) = if w.waiting_for_input {
                     ("⚠ ", theme::waiting_style())
+                } else if w.resurrection_attempts >= 3 {
+                    ("⟳ ", attention_style)
+                } else if w.resurrection_attempts > 0 {
+                    ("⟳ ", reviving_style)
                 } else {
                     match &w.status.state {
                         crate::model::status::AgentState::Working { .. } => {
@@ -301,6 +309,10 @@ impl RepoView {
 
                 let status_text = if w.waiting_for_input {
                     "NEEDS INPUT".to_string()
+                } else if w.resurrection_attempts > 1 {
+                    format!("Reviving (×{})", w.resurrection_attempts)
+                } else if w.resurrection_attempts == 1 {
+                    "Reviving...".to_string()
                 } else {
                     w.status.state.to_string()
                 };

--- a/src/ui/repos_list.rs
+++ b/src/ui/repos_list.rs
@@ -288,6 +288,7 @@ mod tests {
             current_issue: None,
             current_issue_title: None,
             waiting_for_input: false,
+            resurrection_attempts: 0,
         }
     }
 

--- a/src/ui/swarm_view.rs
+++ b/src/ui/swarm_view.rs
@@ -552,6 +552,7 @@ mod tests {
             current_issue: None,
             current_issue_title: None,
             waiting_for_input: false,
+            resurrection_attempts: 0,
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `resurrection_attempts: u32` to `AgentInfo` (default 0)
- `revive_dropped_agents()` increments counter for workers with `Stopped`/`Unknown` state before each revival attempt
- Counter resets to 0 when worker transitions to `Working`/`Idle`
- Repo View shows `⟳` (cyan) for workers being revived, `⟳` (red/bold) for workers with 3+ failed attempts
- Status text shows "Reviving..." / "Reviving (×N)" during revival

## Test plan
- [ ] `cargo test` passes (107 tests)
- [ ] Manual: kill a worker's tmux pane, verify `⟳` appears after the 60-second revival tick

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)