### PR TITLE
Implement #162: Show dispatched_issue status in worker list

### DIFF
--- a/src/ui/repo_view.rs
+++ b/src/ui/repo_view.rs
@@ -345,9 +345,18 @@ impl RepoView {
                     Span::styled(dot, if w.waiting_for_input { row_style } else { dot_style }),
                     Span::styled(role_label, if w.waiting_for_input { row_style } else { theme::title_style() }),
                 ]);
+                let dispatch_label = match w.dispatched_issue {
+                    Some(n) => match &w.status.state {
+                        crate::model::status::AgentState::Working { issue: Some(working_n) }
+                            if *working_n == n => String::new(),
+                        _ => format!(" ⊕#{n}"),
+                    },
+                    None => String::new(),
+                };
                 let line2 = Line::from(vec![
                     Span::styled("  ", row_style),
                     Span::styled(status_text, if w.waiting_for_input { row_style } else { status_style }),
+                    Span::styled(dispatch_label, theme::help_style()),
                 ]);
                 let mut lines = vec![line1, line2];
                 if !elapsed.is_empty() {

--- a/src/ui/swarm_view.rs
+++ b/src/ui/swarm_view.rs
@@ -238,6 +238,16 @@ impl SwarmView {
                         _ => "\u{2014}".to_string(),
                     }
                 };
+                let task = match w.dispatched_issue {
+                    Some(n) if !task.contains(&format!("#{n}")) => {
+                        if task == "\u{2014}" {
+                            format!("→#{n}")
+                        } else {
+                            format!("{task} →#{n}")
+                        }
+                    }
+                    _ => task,
+                };
                 Row::new(vec![
                     Cell::from(format!("{}", i + 1)),
                     Cell::from(status_str).style(status_style),


### PR DESCRIPTION
## Summary
- `repo_view.rs`: Appends ` ⊕#N` to the worker status line when an issue is dispatched but not yet started
- `swarm_view.rs`: Appends ` →#N` to the task cell under the same condition

Indicators disappear once the worker's status reflects the issue number, avoiding duplicate display.

Closes #162

## Test plan
- [x] `cargo test` — 107 tests pass, 0 failures
- [x] `cargo build` — clean build, no warnings
- [ ] Manual: launch a swarm, dispatch an issue to a worker, verify ⊕#N appears in repo view and →#N in swarm view
- [ ] Manual: verify indicator disappears once worker transitions to Working{issue: Some(N)}

🤖 Generated with [Claude Code](https://claude.com/claude-code)