### PR TITLE
Fix #165: Add next-step guidance to blocked issues in attention panel

### DIFF
--- a/src/model/issue.rs
+++ b/src/model/issue.rs
@@ -100,6 +100,18 @@ pub const BLOCKING_LABELS: &[&str] = &[
     "proposal",
 ];
 
+pub fn blocking_guidance(label: &str) -> &'static str {
+    match label {
+        "needs-design" => "add design doc or spec to issue",
+        "needs-approval" => "request stakeholder sign-off",
+        "needs-clarification" => "reply with additional context",
+        "too-complex" => "break into sub-tasks manually",
+        "future" => "defer — remove label to unblock",
+        "proposal" => "approve by removing proposal label",
+        _ => "review and remove blocking label to unblock",
+    }
+}
+
 impl GitHubIssue {
     pub fn is_blocked(&self) -> bool {
         self.labels

--- a/src/ui/swarm_view.rs
+++ b/src/ui/swarm_view.rs
@@ -147,9 +147,14 @@ impl SwarmView {
                     .find(|l| crate::model::issue::BLOCKING_LABELS.contains(&l.as_str()))
                     .map(|s| s.as_str())
                     .unwrap_or("blocked");
+                let guidance = crate::model::issue::blocking_guidance(blocking_label);
                 attn_spans.push(Span::styled(
-                    format!("#{} [{}] {}", issue.number, blocking_label, truncate(&issue.title, 30)),
+                    format!("#{} [{}] {}", issue.number, blocking_label, truncate(&issue.title, 25)),
                     theme::attention_style(),
+                ));
+                attn_spans.push(Span::styled(
+                    format!(" → {}", guidance),
+                    theme::help_style(),
                 ));
             }
             if blocked_count > 3 {


### PR DESCRIPTION
## Summary
- Adds `blocking_guidance(label)` to `src/model/issue.rs` mapping each blocking label to a short action hint
- Attention panel in `swarm_view.rs` appends a dim `→ <guidance>` suffix after each blocked issue
- Example: `needs-design` shows `→ add design doc or spec to issue`

## Test plan
- [ ] `cargo test` passes
- [ ] Manual: create a blocked issue, verify guidance text appears in the attention panel
- [ ] Verify guidance text is dimmed (help_style)

🤖 Generated with [Claude Code](https://claude.com/claude-code)