### PR TITLE
Fix #165: Add next-step guidance to blocked issues in attention panel

### DIFF
--- a/src/model/issue.rs
+++ b/src/model/issue.rs
@@ -100,6 +100,19 @@ pub const BLOCKING_LABELS: &[&str] = &[
     "proposal",
 ];
 
+/// Returns a short action hint for a blocking label.
+pub fn blocking_guidance(label: &str) -> &'static str {
+    match label {
+        "needs-design" => "Add design doc or spec to issue",
+        "needs-approval" => "Request stakeholder sign-off",
+        "needs-clarification" => "Reply with additional context",
+        "too-complex" => "Break into sub-tasks manually",
+        "future" => "Defer — remove label to unblock",
+        "proposal" => "Remove proposal label to approve",
+        _ => "Review and remove blocking label to unblock",
+    }
+}
+
 impl GitHubIssue {
     pub fn is_blocked(&self) -> bool {
         self.labels

--- a/src/ui/swarm_view.rs
+++ b/src/ui/swarm_view.rs
@@ -147,9 +147,14 @@ impl SwarmView {
                     .find(|l| crate::model::issue::BLOCKING_LABELS.contains(&l.as_str()))
                     .map(|s| s.as_str())
                     .unwrap_or("blocked");
+                let guidance = crate::model::issue::blocking_guidance(blocking_label);
                 attn_spans.push(Span::styled(
-                    format!("#{} [{}] {}", issue.number, blocking_label, truncate(&issue.title, 30)),
+                    format!("#{} [{}] {}", issue.number, blocking_label, truncate(&issue.title, 25)),
                     theme::attention_style(),
+                ));
+                attn_spans.push(Span::styled(
+                    format!(" → {}", guidance),
+                    theme::help_style(),
                 ));
             }
             if blocked_count > 3 {


### PR DESCRIPTION
## Summary
- `model/issue.rs`: Adds `blocking_guidance(label)` mapping each blocking label to a short action hint
- `swarm_view.rs`: Appends ` → <guidance>` in `help_style` after each blocked issue in the attention header row

Example: `#42 [needs-design] My feature → Add design doc or spec to issue`

Closes #165

## Test plan
- [x] `cargo test` — 107 tests pass
- [x] `cargo build` — clean build
- [ ] Manual: blocked issue in attention panel shows guidance text

🤖 Generated with [Claude Code](https://claude.com/claude-code)