### PR TITLE
Fix #173: Show issue type indicator (B/E/P) in issues table

### DIFF
--- a/src/model/issue.rs
+++ b/src/model/issue.rs
@@ -138,6 +138,16 @@ impl GitHubIssue {
             .unwrap_or_else(|| "—".to_string())
     }
 
+    /// Returns a single-character type indicator for display in the issues table.
+    pub fn type_char(&self) -> &'static str {
+        match self.issue_type {
+            IssueType::Bug => "B",
+            IssueType::Enhancement => "E",
+            IssueType::Proposal => "P",
+            IssueType::Other => "·",
+        }
+    }
+
     pub fn status_label(&self) -> String {
         if self.is_being_worked() {
             if let Some(ref w) = self.assigned_worker {
@@ -160,7 +170,6 @@ impl GitHubIssue {
         }
     }
 
-    /// Whether this issue matches the given filter.
     pub fn matches_filter(&self, filter: IssueFilter) -> bool {
         match filter {
             IssueFilter::All => true,
@@ -349,6 +358,14 @@ mod tests {
         assert_eq!(IssueFilter::All.next(), IssueFilter::Open);
         assert_eq!(IssueFilter::Open.next(), IssueFilter::Blocked);
         assert_eq!(IssueFilter::Blocked.next(), IssueFilter::All);
+    }
+
+    #[test]
+    fn type_char_returns_correct_indicator() {
+        assert_eq!(make_issue(1, &["bug"]).type_char(), "B");
+        assert_eq!(make_issue(2, &["enhancement"]).type_char(), "E");
+        assert_eq!(make_issue(3, &["proposal"]).type_char(), "P");
+        assert_eq!(make_issue(4, &[]).type_char(), "·");
     }
 
     #[test]

--- a/src/ui/swarm_view.rs
+++ b/src/ui/swarm_view.rs
@@ -322,6 +322,7 @@ impl SwarmView {
 
         let issue_header = Row::new(vec![
             Cell::from("#"),
+            Cell::from("T"),
             Cell::from("Pri"),
             Cell::from("Title"),
             Cell::from("Status"),
@@ -339,8 +340,15 @@ impl SwarmView {
                 } else {
                     Style::default().fg(ratatui::style::Color::Gray)
                 };
+                let type_style = match issue.issue_type {
+                    crate::model::issue::IssueType::Bug => Style::default().fg(ratatui::style::Color::Red),
+                    crate::model::issue::IssueType::Enhancement => Style::default().fg(ratatui::style::Color::Cyan),
+                    crate::model::issue::IssueType::Proposal => Style::default().fg(ratatui::style::Color::Magenta),
+                    crate::model::issue::IssueType::Other => Style::default().fg(ratatui::style::Color::DarkGray),
+                };
                 Row::new(vec![
                     Cell::from(format!("{}", issue.number)),
+                    Cell::from(issue.type_char()).style(type_style),
                     Cell::from(issue.priority_label()),
                     Cell::from(truncate(&issue.title, 30)),
                     Cell::from(status).style(status_style),
@@ -361,6 +369,7 @@ impl SwarmView {
             issue_rows,
             [
                 Constraint::Length(5),
+                Constraint::Length(3),
                 Constraint::Length(4),
                 Constraint::Min(15),
                 Constraint::Length(18),


### PR DESCRIPTION
## Summary
- Adds `type_char()` to `GitHubIssue` returning `B`/`E`/`P`/`·` based on `issue_type`
- Adds color-coded `T` column to the Swarm View issues table (red=Bug, cyan=Enhancement, magenta=Proposal, gray=Other)
- Adds unit test `type_char_returns_correct_indicator` in `src/model/issue.rs`

## Test plan
- [x] `cargo test` — 117 tests pass
- [x] Column layout verified (Length(5), Length(3), Length(4), Min(15), Length(18))

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)