### PR TITLE
Fix #164: Show comment count, assignees, and created-at in Issue Detail view

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2857,7 +2857,7 @@ impl App {
                     "view".to_string(),
                     issue_number.to_string(),
                     "--json".to_string(),
-                    "number,title,body,labels,state".to_string(),
+                    "number,title,body,labels,state,comments,assignees,createdAt".to_string(),
                 ],
             )
             .await
@@ -2879,6 +2879,34 @@ impl App {
                                 .collect()
                         })
                         .unwrap_or_default();
+                    let comment_count = json["comments"]
+                        .as_array()
+                        .map(|arr| arr.len() as u32)
+                        .unwrap_or(0);
+                    let assignees: Vec<String> = json["assignees"]
+                        .as_array()
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|a| a["login"].as_str().map(|s| s.to_string()))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let created_at_age = json["createdAt"]
+                        .as_str()
+                        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                        .map(|dt| {
+                            let secs = (chrono::Utc::now() - dt.to_utc()).num_seconds().max(0) as u64;
+                            if secs < 3600 {
+                                format!("{}m ", secs / 60)
+                            } else if secs < 86400 {
+                                format!("{}h ", secs / 3600)
+                            } else if secs < 7 * 86400 {
+                                format!("{}d ", secs / 86400)
+                            } else {
+                                format!("{}w ", secs / (7 * 86400))
+                            }
+                        })
+                        .unwrap_or_default();
 
                     self.issue_detail_view = Some(IssueDetailView::new(
                         issue_number,
@@ -2886,6 +2914,9 @@ impl App {
                         body,
                         labels,
                         state,
+                        comment_count,
+                        assignees,
+                        created_at_age,
                     ));
                     self.screen = Screen::IssueDetail { swarm_idx };
                 }

--- a/src/ui/issue_detail.rs
+++ b/src/ui/issue_detail.rs
@@ -34,10 +34,22 @@ pub struct IssueDetailView {
     pub body: String,
     pub labels: Vec<String>,
     pub state: String,
+    pub comment_count: u32,
+    pub assignees: Vec<String>,
+    pub created_at_age: String,
 }
 
 impl IssueDetailView {
-    pub fn new(issue_number: u32, title: String, body: String, labels: Vec<String>, state: String) -> Self {
+    pub fn new(
+        issue_number: u32,
+        title: String,
+        body: String,
+        labels: Vec<String>,
+        state: String,
+        comment_count: u32,
+        assignees: Vec<String>,
+        created_at_age: String,
+    ) -> Self {
         Self {
             scroll_offset: 0,
             issue_number,
@@ -45,6 +57,9 @@ impl IssueDetailView {
             body,
             labels,
             state,
+            comment_count,
+            assignees,
+            created_at_age,
         }
     }
 
@@ -58,7 +73,7 @@ impl IssueDetailView {
 
     pub fn render(&self, f: &mut Frame, area: Rect) {
         let chunks = Layout::vertical([
-            Constraint::Length(4), // Header
+            Constraint::Length(5), // Header (extra line for metadata)
             Constraint::Min(5),   // Body
             Constraint::Length(3), // Help bar
         ])
@@ -70,6 +85,26 @@ impl IssueDetailView {
         } else {
             self.labels.join(" · ")
         };
+
+        let assignee_text = if self.assignees.is_empty() {
+            "unassigned".to_string()
+        } else {
+            self.assignees.join(", ")
+        };
+        let comment_text = match self.comment_count {
+            0 => "no comments".to_string(),
+            1 => "1 comment".to_string(),
+            n => format!("{n} comments"),
+        };
+        let age_text = if self.created_at_age.is_empty() {
+            String::new()
+        } else {
+            format!("created {}ago", self.created_at_age)
+        };
+        let mut meta_parts = vec![assignee_text, comment_text];
+        if !age_text.is_empty() {
+            meta_parts.push(age_text);
+        }
 
         let header_lines = vec![
             Line::from(vec![
@@ -97,6 +132,10 @@ impl IssueDetailView {
                 }
                 Line::from(spans)
             },
+            Line::from(Span::styled(
+                format!(" {}", meta_parts.join("  ·  ")),
+                theme::help_style(),
+            )),
         ];
 
         let header = Paragraph::new(header_lines)
@@ -144,6 +183,35 @@ impl IssueDetailView {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn make_view(comment_count: u32, assignees: &[&str], created_at_age: &str) -> IssueDetailView {
+        IssueDetailView::new(
+            42,
+            "Test issue".to_string(),
+            "Body text".to_string(),
+            vec!["bug".to_string()],
+            "OPEN".to_string(),
+            comment_count,
+            assignees.iter().map(|s| s.to_string()).collect(),
+            created_at_age.to_string(),
+        )
+    }
+
+    #[test]
+    fn new_stores_metadata_fields() {
+        let view = make_view(5, &["alice", "bob"], "3d ");
+        assert_eq!(view.comment_count, 5);
+        assert_eq!(view.assignees, vec!["alice", "bob"]);
+        assert_eq!(view.created_at_age, "3d ");
+    }
+
+    #[test]
+    fn new_empty_metadata() {
+        let view = make_view(0, &[], "");
+        assert_eq!(view.comment_count, 0);
+        assert!(view.assignees.is_empty());
+        assert!(view.created_at_age.is_empty());
+    }
 
     #[test]
     fn count_tasks_no_tasks() {


### PR DESCRIPTION
## Summary
- Adds `comment_count`, `assignees`, `created_at_age` fields to `IssueDetailView`
- Issue Detail header gains a third metadata line: `<assignee>  ·  <N comments>  ·  created <age>ago`
- Header height increased from 4 to 5 rows to accommodate the new line
- Extends `--json` fields in `open_issue_detail()` to include `comments`, `assignees`, `createdAt` — no additional API calls

## Test plan
- [x] `cargo test` passes (124 tests, 2 new for metadata fields)
- [x] Graceful empty states: "unassigned" when no assignee, "no comments" when zero, age omitted when unavailable
- [x] Existing count_tasks tests unaffected

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)