### PR TITLE
Fix #184: Remove duplicate T column from Issues table

### DIFF
--- a/src/ui/swarm_view.rs
+++ b/src/ui/swarm_view.rs
@@ -323,7 +323,6 @@ impl SwarmView {
         let issue_header = Row::new(vec![
             Cell::from("T"),
             Cell::from("#"),
-            Cell::from("T"),
             Cell::from("Pri"),
             Cell::from("Title"),
             Cell::from("Status"),
@@ -341,16 +340,9 @@ impl SwarmView {
                 } else {
                     Style::default().fg(ratatui::style::Color::Gray)
                 };
-                let type_style = match issue.issue_type {
-                    crate::model::issue::IssueType::Bug => Style::default().fg(ratatui::style::Color::Red),
-                    crate::model::issue::IssueType::Enhancement => Style::default().fg(ratatui::style::Color::Cyan),
-                    crate::model::issue::IssueType::Proposal => Style::default().fg(ratatui::style::Color::Magenta),
-                    crate::model::issue::IssueType::Other => Style::default().fg(ratatui::style::Color::DarkGray),
-                };
                 Row::new(vec![
                     Cell::from(issue.type_char()).style(theme::issue_type_style(&issue.issue_type)),
                     Cell::from(format!("{}", issue.number)),
-                    Cell::from(issue.type_char()).style(type_style),
                     Cell::from(issue.priority_label()),
                     Cell::from(truncate(&issue.title, 30)),
                     Cell::from(status).style(status_style),
@@ -372,7 +364,6 @@ impl SwarmView {
             [
                 Constraint::Length(3),
                 Constraint::Length(5),
-                Constraint::Length(3),
                 Constraint::Length(4),
                 Constraint::Min(15),
                 Constraint::Length(18),


### PR DESCRIPTION
## Summary
- Removes duplicate type (`T`) column at index 2 from the Issues table in Swarm View
- Both header and row data had `type_char()` rendered twice (col 0 and col 2)
- Also removes the now-unused `type_style` local variable and the corresponding `Constraint::Length(3)`

## Test plan
- [x] `cargo build` — no errors, 2 pre-existing warnings unchanged
- [x] `cargo test` — 144 tests pass

Fixes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)