### PR TITLE
Fix #197: Render blockquotes and horizontal rules in Issue Detail markdown

### DIFF
--- a/src/ui/issue_detail.rs
+++ b/src/ui/issue_detail.rs
@@ -62,6 +62,19 @@ pub fn render_markdown_line(line: &str) -> Line<'static> {
         }
     }
 
+    // Blockquote: > text
+    if let Some(text) = trimmed.strip_prefix("> ").or_else(|| trimmed.strip_prefix(">")) {
+        return Line::from(vec![
+            Span::styled("│ ", theme::help_style()),
+            Span::styled(text.to_string(), Style::default().fg(Color::Gray)),
+        ]);
+    }
+
+    // Horizontal rule: ---, ***, ___
+    if trimmed == "---" || trimmed == "***" || trimmed == "___" {
+        return Line::from(Span::styled("─────────────────────", theme::help_style()));
+    }
+
     // Plain line — handle inline code and bold inline
     let owned = line.to_string();
     let spans = parse_inline(&owned);
@@ -395,5 +408,20 @@ mod tests {
         let line = render_markdown_line("123");
         let combined: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(combined, "123");
+    }
+
+    #[test]
+    fn render_markdown_line_blockquote() {
+        let line = render_markdown_line("> quoted text");
+        assert_eq!(line.spans.len(), 2);
+        assert!(line.spans[0].content.contains('│'));
+        assert_eq!(line.spans[1].content, "quoted text");
+    }
+
+    #[test]
+    fn render_markdown_line_horizontal_rule() {
+        let line = render_markdown_line("---");
+        assert_eq!(line.spans.len(), 1);
+        assert!(line.spans[0].content.contains('─'));
     }
 }


### PR DESCRIPTION
## Summary
- Add blockquote rendering: `> text` → `│ text` with gray styling
- Add horizontal rule rendering: `---`, `***`, `___` → styled separator line
- Added tests for both new patterns

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)