### PR TITLE
Fix #269: Add unit tests for ReposListView navigation

### DIFF
--- a/src/ui/repos_list.rs
+++ b/src/ui/repos_list.rs
@@ -338,6 +338,57 @@ mod tests {
     }
 
     #[test]
+    fn new_starts_selected_at_zero() {
+        let view = ReposListView::new();
+        assert_eq!(view.selected(), Some(0));
+    }
+
+    #[test]
+    fn next_increments_selection() {
+        let mut view = ReposListView::new();
+        view.next(3);
+        assert_eq!(view.selected(), Some(1));
+    }
+
+    #[test]
+    fn next_wraps_at_end() {
+        let mut view = ReposListView::new();
+        view.next(3); // 0 -> 1
+        view.next(3); // 1 -> 2
+        view.next(3); // 2 -> 0 (wrap)
+        assert_eq!(view.selected(), Some(0));
+    }
+
+    #[test]
+    fn previous_decrements_selection() {
+        let mut view = ReposListView::new();
+        view.next(3); // 0 -> 1
+        view.previous(3); // 1 -> 0
+        assert_eq!(view.selected(), Some(0));
+    }
+
+    #[test]
+    fn previous_wraps_to_last() {
+        let mut view = ReposListView::new();
+        view.previous(3); // 0 -> 2 (wrap)
+        assert_eq!(view.selected(), Some(2));
+    }
+
+    #[test]
+    fn next_with_empty_list_does_not_panic() {
+        let mut view = ReposListView::new();
+        view.next(0);
+        assert_eq!(view.selected(), Some(0));
+    }
+
+    #[test]
+    fn previous_with_empty_list_does_not_panic() {
+        let mut view = ReposListView::new();
+        view.previous(0);
+        assert_eq!(view.selected(), Some(0));
+    }
+
+    #[test]
     fn render_smoke_shows_active_and_available_repos() {
         use std::collections::HashMap;
         let backend = TestBackend::new(120, 30);


### PR DESCRIPTION
Adds 7 unit tests for `ReposListView` navigation methods in `src/ui/repos_list.rs`:

- `new_starts_selected_at_zero`
- `next_increments_selection`
- `next_wraps_at_end`
- `previous_decrements_selection`
- `previous_wraps_to_last`
- `next_with_empty_list_does_not_panic`
- `previous_with_empty_list_does_not_panic`

All 8 tests pass (`cargo test repos_list`).

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)