### PR TITLE
Fix #274: add unit tests for help_overlay, shortcuts_viewer, and switch_agent_dialog

### DIFF
--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -92,6 +92,51 @@ pub fn render_help_overlay(
     f.render_widget(table, popup_area);
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::keybindings::KeyBindings;
+    use ratatui::{Terminal, backend::TestBackend};
+
+    #[test]
+    fn render_help_overlay_smoke() {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let keybindings = KeyBindings::default();
+        terminal
+            .draw(|f| render_help_overlay(f, f.area(), &keybindings, None))
+            .unwrap();
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(rendered.contains("Keyboard Shortcuts"));
+    }
+
+    #[test]
+    fn render_help_overlay_with_context_shows_issues_section() {
+        let backend = TestBackend::new(80, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let keybindings = KeyBindings::default();
+        terminal
+            .draw(|f| {
+                render_help_overlay(f, f.area(), &keybindings, Some(ISSUES_PANEL_CONTEXT))
+            })
+            .unwrap();
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(rendered.contains("Issues Panel"));
+    }
+}
+
 /// Issue panel context entries for the help overlay.
 pub const ISSUES_PANEL_CONTEXT: &[(&str, &str)] = &[
     ("cycle status filter", "f"),

--- a/src/ui/new_swarm.rs
+++ b/src/ui/new_swarm.rs
@@ -628,9 +628,9 @@ pub fn render_create_issue_dialog(f: &mut Frame, area: Rect, form: &CreateIssueF
 mod tests {
     use super::{
         render_create_issue_dialog, render_install_scope_dialog, render_new_swarm_dialog,
-        render_runtime_dialog,
+        render_runtime_dialog, render_switch_agent_dialog,
     };
-    use crate::app::{CreateIssueForm, InstallScope, NewSwarmField};
+    use crate::app::{CreateIssueForm, InstallScope, NewSwarmField, RuntimeOption};
     use crate::model::swarm::AgentType;
     use crate::ui::text_input::TextInput;
     use ratatui::{Terminal, backend::TestBackend};
@@ -730,5 +730,31 @@ mod tests {
         assert!(rendered.contains("needs-design"));
         assert!(rendered.contains("proposal"));
         assert!(rendered.contains("create"));
+    }
+
+    #[test]
+    fn switch_agent_dialog_shows_project_and_runtimes() {
+        let options = vec![
+            RuntimeOption {
+                agent_type: AgentType::Codex,
+                available: true,
+                detail: "(current)".to_string(),
+            },
+            RuntimeOption {
+                agent_type: AgentType::Claude,
+                available: true,
+                detail: String::new(),
+            },
+        ];
+        let rendered = rendered_text(|terminal| {
+            terminal
+                .draw(|f| {
+                    render_switch_agent_dialog(f, f.area(), "demo", &AgentType::Codex, &options, 0)
+                })
+                .unwrap();
+        });
+        assert!(rendered.contains("Switch agent runtime for demo"));
+        assert!(rendered.contains("Codex"));
+        assert!(rendered.contains("Claude"));
     }
 }

--- a/src/ui/shortcuts_viewer.rs
+++ b/src/ui/shortcuts_viewer.rs
@@ -87,3 +87,46 @@ pub fn render_shortcuts_viewer(
     let paragraph = Paragraph::new(lines).wrap(Wrap { trim: false });
     f.render_widget(paragraph, inner);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::shortcuts::ShortcutsConfig;
+    use ratatui::{Terminal, backend::TestBackend};
+
+    #[test]
+    fn render_shortcuts_viewer_smoke() {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let config = ShortcutsConfig::defaults();
+        terminal
+            .draw(|f| render_shortcuts_viewer(f, f.area(), &config, "agents"))
+            .unwrap();
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(rendered.contains("Shortcuts"));
+    }
+
+    #[test]
+    fn render_shortcuts_viewer_shows_active_panel() {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let config = ShortcutsConfig::defaults();
+        terminal
+            .draw(|f| render_shortcuts_viewer(f, f.area(), &config, "repos"))
+            .unwrap();
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(rendered.contains("repos"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add smoke tests for `render_help_overlay` (with and without context entries)
- Add smoke tests for `render_shortcuts_viewer` (panel name shown, content present)
- Add test for `render_switch_agent_dialog` using the current `RuntimeOption`-based signature

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)