### PR TITLE
Fix #278: exclude AgentView from shortcuts-viewer '?' intercept

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1102,6 +1102,7 @@ impl App {
                     | Screen::NewSwarm { .. }
                     | Screen::RuntimeSelect
                     | Screen::InstallScopeSelect
+                    | Screen::AgentView { .. }
             )
         {
             self.show_shortcuts_viewer = true;


### PR DESCRIPTION
## Summary
- Add `Screen::AgentView { .. }` to the exclusion list in the `?` key guard in `src/app.rs:1097`
- `?` now forwards to the tmux pane when in agent view, matching the documented passthrough behavior

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)