### PR TITLE
Fix #132: wire up shortcuts in issue-list screen; fix dead code warnings

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3900,7 +3900,18 @@ impl App {
                 self.start_issue_refresh(swarm_idx);
                 self.status_message = Some("Refreshing issues...".to_string());
             }
-            _ => {}
+            _ => {
+                // Fall through to config-driven shortcuts (e.g. x=fix, b=brainstorm)
+                if let KeyCode::Char(c) = key.code {
+                    let issue_num = self.swarms.get(swarm_idx)
+                        .and_then(|s| self.issue_caches.get(&s.project_name))
+                        .and_then(|cache| {
+                            let sorted = IssueListView::sorted_open(&cache.issues);
+                            self.issue_list_view.selected().and_then(|i| sorted.get(i)).map(|iss| iss.number)
+                        });
+                    self.try_shortcut("issues", &c.to_string(), swarm_idx, issue_num).await?;
+                }
+            }
         }
         Ok(())
     }
@@ -5219,6 +5230,7 @@ async fn gemini_support_root(
     None
 }
 
+#[cfg(test)]
 async fn gemini_agents_assets_present(
     transport: &ServerTransport,
     agents_dir: Option<&std::path::Path>,

--- a/src/config/shortcuts.rs
+++ b/src/config/shortcuts.rs
@@ -121,9 +121,10 @@ const DEFAULT_CONFIG: &str = r#"# agents-ui keyboard shortcuts
 # Panels: [global], [workers], [issues], [manager]
 # Fields: label (display name), command (template), target ("manager" or "worker"), raw (bool)
 # Variables: {issue} = selected issue number, {worker} = worker tmux target, {project} = project name
+#
+# Note: keys explicitly bound in the TUI (j/k/enter/esc/p/r/d/space) take priority over shortcuts.
 
 [issues]
-a = { label = "approve", command = "gh issue edit {issue} --remove-label proposal" }
 x = { label = "fix", command = "/autocoder:fix {issue}" }
 b = { label = "brainstorm", command = "/brainstorm {issue}" }
 

--- a/src/model/swarm.rs
+++ b/src/model/swarm.rs
@@ -64,6 +64,7 @@ impl AgentType {
     }
 
     /// The shell command to launch this agent with autonomous permissions.
+    #[cfg(test)]
     pub fn launch_cmd(&self) -> &str {
         match self {
             AgentType::Claude => "claude code --dangerously-skip-permissions .",


### PR DESCRIPTION
## Summary
- Adds `try_shortcut("issues")` fallback in `handle_issue_list_key` so config-defined shortcuts (x=fix, b=brainstorm) work in the full-screen issue list — consistent with the existing `handle_repo_view_key` behavior
- Removes misleading `a = approve` from DEFAULT_CONFIG (pressing `a` opens the create-issue dialog, not approve; `p` approves — the shortcuts viewer was showing incorrect info)
- Marks `gemini_agents_assets_present` as `#[cfg(test)]` — only used in tests
- Marks `AgentType::launch_cmd` as `#[cfg(test)]` — only used in tests

Both `#[cfg(test)]` changes eliminate dead_code warnings without removing valid test helpers.

## Test plan
- [x] `cargo build` — zero warnings
- [x] `cargo test` — 283 tests pass (1 pre-existing Gemini integration test failure unrelated to this change)
- [x] Pressing `x` on a selected issue in the IssueList screen now sends the fix command to the manager

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)