### PR TITLE
Fix #306: add Stop, Add Worker, and Start buttons to web UI swarm view

### DIFF
--- a/src/web/server.rs
+++ b/src/web/server.rs
@@ -4,7 +4,7 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::Html,
-    routing::{get, post},
+    routing::{delete, get, post},
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -240,6 +240,169 @@ async fn api_launch_swarm_handler(
     Ok(Json(json!({ "ok": true, "project_name": project_name })))
 }
 
+/// Stop a running swarm by killing its tmux session.
+/// `DELETE /api/swarms/:project`
+async fn api_stop_swarm_handler(
+    Path(project): Path<String>,
+    State(state): State<WebServerState>,
+) -> Result<Json<Value>, StatusCode> {
+    let tmux_session = {
+        let guard = state
+            .swarms
+            .read()
+            .map_err(|e| {
+                tracing::warn!("Web state lock poisoned: {e}");
+            })
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        guard
+            .iter()
+            .find(|s| s.project_name == project)
+            .map(|s| s.tmux_session.clone())
+            .ok_or(StatusCode::NOT_FOUND)?
+    };
+
+    // Mark as intentionally stopped (prevents auto-respawn by heal_workers).
+    crate::config::persistence::mark_swarm_stopped(&project);
+
+    // Kill the tmux session.
+    let output = tokio::process::Command::new("tmux")
+        .args(["kill-session", "-t", &tmux_session])
+        .output()
+        .await
+        .map_err(|e| {
+            tracing::warn!("Failed to run tmux kill-session for {tmux_session}: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // "can't find session" is fine — already stopped.
+        if !stderr.contains("can't find session") {
+            tracing::warn!("tmux kill-session failed for {tmux_session}: {stderr}");
+        }
+    }
+
+    Ok(Json(json!({ "ok": true })))
+}
+
+/// Add a new worker to a running swarm.
+/// `POST /api/swarms/:project/workers`
+/// Returns 202 Accepted immediately; the worker is launched in a background task.
+async fn api_add_worker_handler(
+    Path(project): Path<String>,
+    State(state): State<WebServerState>,
+) -> Result<Json<Value>, StatusCode> {
+    use crate::adapter::claude::ClaudeAdapter;
+    use crate::adapter::traits::AgentRuntime;
+    use crate::model::swarm::AgentType;
+    use crate::transport::ServerTransport;
+
+    let (repo_path_str, agent_type_str, tmux_session, num_workers) = {
+        let guard = state
+            .swarms
+            .read()
+            .map_err(|e| {
+                tracing::warn!("Web state lock poisoned: {e}");
+            })
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        let snap = guard
+            .iter()
+            .find(|s| s.project_name == project)
+            .ok_or(StatusCode::NOT_FOUND)?;
+        if snap.stopped {
+            return Err(StatusCode::CONFLICT);
+        }
+        (
+            snap.repo_path.clone(),
+            snap.agent_type.clone(),
+            snap.tmux_session.clone(),
+            snap.workers.len(),
+        )
+    };
+
+    let agent_type: AgentType = match agent_type_str.as_str() {
+        "Claude" => AgentType::Claude,
+        "Codex"  => AgentType::Codex,
+        "Droid"  => AgentType::Droid,
+        "Gemini" => AgentType::Gemini,
+        _ => return Err(StatusCode::BAD_REQUEST),
+    };
+
+    let repo_path = PathBuf::from(&repo_path_str);
+    if !repo_path.exists() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    // Build a minimal Swarm so ClaudeAdapter::add_worker can determine the next
+    // worker number and the tmux session/repo context.  Only .workers.len(),
+    // .project_name, .repo_path, and .tmux_session are used by add_worker.
+    let swarm = build_minimal_swarm(
+        project.clone(),
+        repo_path,
+        agent_type.clone(),
+        tmux_session,
+        num_workers,
+    );
+
+    let project_log = project.clone();
+    tokio::spawn(async move {
+        let adapter = ClaudeAdapter::new(agent_type, ServerTransport::new(None));
+        match adapter.add_worker(&swarm).await {
+            Ok(worker) => tracing::info!("Added {} to swarm {}", worker.role, project_log),
+            Err(e) => tracing::error!("Failed to add worker to {}: {e:#}", project_log),
+        }
+    });
+
+    Ok(Json(json!({ "ok": true, "project_name": project })))
+}
+
+/// Build a minimal `Swarm` from snapshot data for use with `ClaudeAdapter::add_worker`.
+/// Only the fields consumed by `add_worker` need real values.
+fn build_minimal_swarm(
+    project_name: String,
+    repo_path: PathBuf,
+    agent_type: crate::model::swarm::AgentType,
+    tmux_session: String,
+    num_workers: usize,
+) -> crate::model::swarm::Swarm {
+    use crate::model::status::{AgentState, AgentStatus};
+    use crate::model::swarm::{AgentInfo, WorkerHealth};
+
+    let make_dummy = |role: &str, is_manager: bool| AgentInfo {
+        id: format!("{project_name}/{role}"),
+        role: role.to_string(),
+        worktree_path: repo_path.clone(),
+        tmux_target: String::new(),
+        status: AgentStatus {
+            timestamp: None,
+            state: AgentState::Unknown(String::new()),
+        },
+        is_manager,
+        pane_content: String::new(),
+        dispatched_issue: None,
+        current_issue: None,
+        current_issue_title: None,
+        waiting_for_input: false,
+        resurrection_attempts: 0,
+        completed_issue_count: 0,
+        health: WorkerHealth::default(),
+    };
+
+    crate::model::swarm::Swarm {
+        repo_path: repo_path.clone(),
+        project_name: project_name.clone(),
+        agent_type,
+        workflow: None,
+        tmux_session,
+        manager: make_dummy("manager", true),
+        workers: (1..=num_workers)
+            .map(|n| make_dummy(&format!("worker-{n}"), false))
+            .collect(),
+        issue_cache: crate::model::issue::IssueCache::default(),
+        stopped: false,
+    }
+}
+
 /// Find an agent (manager or worker) by role within a swarm snapshot.
 fn find_agent<'a>(
     swarm: &'a super::SwarmSnapshot,
@@ -259,6 +422,14 @@ pub async fn run(port: u16, state: WebServerState) -> Result<()> {
         .route("/api/swarms", get(api_swarms_handler).post(api_launch_swarm_handler))
         .route("/api/repos", get(api_repos_handler))
         .route("/api/agent-types", get(api_agent_types_handler))
+        .route(
+            "/api/swarms/{project}",
+            delete(api_stop_swarm_handler),
+        )
+        .route(
+            "/api/swarms/{project}/workers",
+            post(api_add_worker_handler),
+        )
         .route(
             "/api/swarms/{project}/agents/{role}/pane",
             get(api_pane_handler),
@@ -299,6 +470,14 @@ mod tests {
             .route("/api/swarms", get(api_swarms_handler).post(api_launch_swarm_handler))
             .route("/api/repos", get(api_repos_handler))
             .route("/api/agent-types", get(api_agent_types_handler))
+            .route(
+                "/api/swarms/{project}",
+                delete(api_stop_swarm_handler),
+            )
+            .route(
+                "/api/swarms/{project}/workers",
+                post(api_add_worker_handler),
+            )
             .route(
                 "/api/swarms/{project}/agents/{role}/pane",
                 get(api_pane_handler),
@@ -577,5 +756,70 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn api_stop_swarm_returns_404_for_unknown_project() {
+        let state = make_web_state(new_shared_state());
+        let app = make_app(state);
+        let req = Request::builder()
+            .method("DELETE")
+            .uri("/api/swarms/ghost-project")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn api_add_worker_returns_404_for_unknown_project() {
+        let state = make_web_state(new_shared_state());
+        let app = make_app(state);
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/swarms/ghost-project/workers")
+            .header("content-type", "application/json")
+            .body(Body::from("{}"))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn api_add_worker_returns_conflict_for_stopped_swarm() {
+        let shared = new_shared_state();
+        {
+            let mut guard = shared.write().unwrap();
+            let mut s = sample_swarm("stopped-proj");
+            s.stopped = true;
+            guard.push(s);
+        }
+        let state = make_web_state(shared);
+        let app = make_app(state);
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/swarms/stopped-proj/workers")
+            .header("content-type", "application/json")
+            .body(Body::from("{}"))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn build_minimal_swarm_worker_count_matches() {
+        use crate::model::swarm::AgentType;
+        let swarm = build_minimal_swarm(
+            "my-proj".to_string(),
+            PathBuf::from("/repos/my-proj"),
+            AgentType::Claude,
+            "claude-my-proj".to_string(),
+            3,
+        );
+        assert_eq!(swarm.workers.len(), 3);
+        assert_eq!(swarm.project_name, "my-proj");
+        assert_eq!(swarm.tmux_session, "claude-my-proj");
+        assert!(swarm.manager.is_manager);
+        assert!(!swarm.workers[0].is_manager);
     }
 }

--- a/src/web/ui.html
+++ b/src/web/ui.html
@@ -603,6 +603,40 @@
 
     .launch-status.ok    { color: var(--success); }
     .launch-status.error { color: var(--error); }
+
+    /* ---- Swarm action bar (Stop / Add Worker / Start) ---- */
+    .swarm-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.625rem;
+      margin-bottom: 1rem;
+    }
+
+    .action-btn {
+      border: none;
+      border-radius: var(--radius);
+      font-weight: 600;
+      font-size: 0.8125rem;
+      padding: 0.375rem 1rem;
+      cursor: pointer;
+      transition: opacity 0.15s;
+    }
+
+    .action-btn:hover   { opacity: 0.85; }
+    .action-btn:active  { opacity: 0.7; }
+    .action-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    .action-btn.stop    { background: var(--error);   color: #fff; }
+    .action-btn.start   { background: var(--success); color: #0d1117; }
+    .action-btn.add     { background: var(--surface); color: var(--text); border: 1px solid var(--border); }
+
+    .action-feedback {
+      font-size: 0.8rem;
+      margin-left: 0.5rem;
+    }
+
+    .action-feedback.ok    { color: var(--success); }
+    .action-feedback.error { color: var(--error); }
   </style>
 </head>
 <body>
@@ -795,6 +829,76 @@
       }
     }
 
+    // ── Swarm actions ─────────────────────────────────────────────────────────
+
+    async function stopSwarm(projectName) {
+      const btn = document.getElementById('swarm-stop-btn');
+      if (btn) { btn.disabled = true; btn.textContent = 'Stopping…'; }
+      setActionFeedback('');
+      try {
+        const r = await fetch('/api/swarms/' + encodeURIComponent(projectName), { method: 'DELETE' });
+        if (r.ok) {
+          setActionFeedback('Swarm stopped.', true);
+          setTimeout(() => { refresh(); }, 1500);
+        } else {
+          setActionFeedback('Stop failed (HTTP ' + r.status + ').', false);
+          if (btn) { btn.disabled = false; btn.textContent = 'Stop'; }
+        }
+      } catch (err) {
+        setActionFeedback('Error: ' + err.message, false);
+        if (btn) { btn.disabled = false; btn.textContent = 'Stop'; }
+      }
+    }
+
+    async function addWorker(projectName) {
+      const btn = document.getElementById('swarm-addworker-btn');
+      if (btn) { btn.disabled = true; btn.textContent = 'Adding…'; }
+      setActionFeedback('');
+      try {
+        const r = await fetch('/api/swarms/' + encodeURIComponent(projectName) + '/workers', { method: 'POST' });
+        if (r.ok) {
+          setActionFeedback('Worker launching…', true);
+          setTimeout(() => { refresh(); }, 5000);
+        } else {
+          setActionFeedback('Add worker failed (HTTP ' + r.status + ').', false);
+        }
+      } catch (err) {
+        setActionFeedback('Error: ' + err.message, false);
+      } finally {
+        if (btn) { btn.disabled = false; btn.textContent = '+ Add Worker'; }
+      }
+    }
+
+    async function startSwarm(projectName, repoPath, agentType) {
+      const btn = document.getElementById('swarm-start-btn');
+      if (btn) { btn.disabled = true; btn.textContent = 'Starting…'; }
+      setActionFeedback('');
+      try {
+        const r = await fetch('/api/swarms', {
+          method:  'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body:    JSON.stringify({ repo_path: repoPath, agent_type: agentType, num_workers: 1 }),
+        });
+        if (r.ok) {
+          setActionFeedback('Swarm starting…', true);
+          setTimeout(() => { refresh(); }, 4000);
+        } else {
+          setActionFeedback('Start failed (HTTP ' + r.status + ').', false);
+          if (btn) { btn.disabled = false; btn.textContent = 'Start'; }
+        }
+      } catch (err) {
+        setActionFeedback('Error: ' + err.message, false);
+        if (btn) { btn.disabled = false; btn.textContent = 'Start'; }
+      }
+    }
+
+    function setActionFeedback(msg, ok) {
+      const el = document.getElementById('swarm-action-feedback');
+      if (!el) return;
+      el.textContent = msg;
+      el.className = 'action-feedback' + (msg ? (ok ? ' ok' : ' error') : '');
+    }
+
     // ── API ────────────────────────────────────────────────────────────────────
     async function fetchSwarms() {
       const r = await fetch('/api/swarms');
@@ -854,6 +958,36 @@
       );
     }
 
+    function renderSwarmActions(swarm) {
+      const p = esc(swarm.project_name);
+      const r = esc(swarm.repo_path);
+      const t = esc(swarm.agent_type);
+      if (swarm.stopped) {
+        return (
+          '<div class="swarm-actions">' +
+            '<button class="action-btn start" id="swarm-start-btn" ' +
+              'onclick="startSwarm(\'' + p + '\',\'' + r + '\',\'' + t + '\')">' +
+              'Start' +
+            '</button>' +
+            '<span id="swarm-action-feedback" class="action-feedback"></span>' +
+          '</div>'
+        );
+      }
+      return (
+        '<div class="swarm-actions">' +
+          '<button class="action-btn stop" id="swarm-stop-btn" ' +
+            'onclick="stopSwarm(\'' + p + '\')">' +
+            'Stop' +
+          '</button>' +
+          '<button class="action-btn add" id="swarm-addworker-btn" ' +
+            'onclick="addWorker(\'' + p + '\')">' +
+            '+ Add Worker' +
+          '</button>' +
+          '<span id="swarm-action-feedback" class="action-feedback"></span>' +
+        '</div>'
+      );
+    }
+
     function renderDetailView(swarm) {
       const workers    = swarm.workers || [];
       const workerRows = workers.length
@@ -878,6 +1012,8 @@
           '<span class="meta-item" style="font-family:monospace;font-size:0.75rem">' + esc(swarm.tmux_session) + '</span>' +
           '<span class="meta-item" style="opacity:0.7">' + esc(swarm.repo_path) + '</span>' +
         '</div>' +
+
+        renderSwarmActions(swarm) +
 
         '<div class="detail-layout">' +
           '<div class="panel">' +


### PR DESCRIPTION
## Summary

- Adds `DELETE /api/swarms/:project` endpoint to stop a swarm (kills tmux session, marks stopped)
- Adds `POST /api/swarms/:project/workers` endpoint to add a worker (launches in background via `ClaudeAdapter::add_worker`)
- Renders Stop and + Add Worker buttons for running swarms; Start button for stopped swarms
- 4 new unit tests covering 404/conflict/worker-count cases

## Test plan

- [x] `cargo test` — all 461 tests pass
- [ ] Manual: verify Stop button kills tmux session and UI updates to show Start
- [ ] Manual: verify + Add Worker button spawns a new worker pane
- [ ] Manual: verify Start button re-launches a stopped swarm

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)