### PR TITLE
Fix #310: increase pane-marker poll timeout to fix flaky test

### DIFF
--- a/src/adapter/claude.rs
+++ b/src/adapter/claude.rs
@@ -2430,7 +2430,7 @@ exit 0
         target: &str,
         markers: &[&str],
     ) -> String {
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(45);
         let mut last = String::new();
         while std::time::Instant::now() < deadline {
             last = adapter.capture_output(target).await.unwrap_or_default();


### PR DESCRIPTION
## Summary

Increases `wait_for_pane_markers` timeout from 20s → 45s in the adapter test suite. Under concurrent `cargo test` execution, tmux sessions start slower due to CPU contention, causing the old timeout to fire before fake agent scripts emit their expected output markers.

The fix is minimal and targeted — no behavioral change, just more headroom. Passing runs still complete in ~16s.

## Test plan

- [x] `cargo test launches_manager` passes
- [x] Ran full `cargo test` — all 468 tests pass

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)